### PR TITLE
DM-26581: Build/deploy cycle 12

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline{
         LTD_PASSWORD="${user_ci_PSW}"
     }
     stages{
-        stage("Build and Upload ATMCS Documentation"){
+        stage("Build and Upload Documentation"){
             steps{
                 sh """
                     source /home/saluser/.setup_dev.sh

--- a/README.md
+++ b/README.md
@@ -50,11 +50,18 @@ Once `cycle.env` is prepared and the user has verified that all the packages exi
 The build starts by building the base image.
 
 ```bash
-docker-compose -f cycle/docker-compose.yaml --env-file cycle/cycle.env build deploy-conda-community
 docker-compose -f cycle/docker-compose.yaml --env-file cycle/cycle.env build deploy-conda-private
+docker-compose -f cycle/docker-compose.yaml --env-file cycle/cycle.env push deploy-conda-private
+docker-compose -f cycle/docker-compose.yaml --env-file cycle/cycle.env build deploy-lsstsqre-private
+docker-compose -f cycle/docker-compose.yaml --env-file cycle/cycle.env push deploy-lsstsqre-private
 ```
 
 Once the base deployment images are built you can build the CSCs that uses those base images.
+WE 
+
+```bash
+
+```
 
 ## Building the development environment
 
@@ -89,6 +96,12 @@ See tstn-023 for more details about shared memory mode and this cycle.
 
 Updating deployment to use disposable QoS for telemetry topics.
 This is an experimental feature on sal/salobj to see if we alleviate the system dictionary by making telemetry disposable.
+This experiment is part of a task to obtain a stable DDS deployment.
+
+## Cycle 0012
+
+Updating deployment to use new partitioning schema implemented in salobj 6/sal 5.
+This is also an experimental feature in sal/salobj to try to improve the how data is organized in the DDS Global Data Storage.
 This experiment is part of a task to obtain a stable DDS deployment.
 
 # Open questions

--- a/build/ataos/Dockerfile.conda
+++ b/build/ataos/Dockerfile.conda
@@ -1,0 +1,42 @@
+ARG cycle
+ARG hub
+
+FROM ${hub}/deploy-env:${cycle}
+
+LABEL maintainer Tiago Ribeiro <tribeiro@lsst.org>
+
+WORKDIR /home/saluser/
+
+RUN git clone https://github.com/lsst-ts/ts_config_attcs.git
+
+WORKDIR /home/saluser/ts_config_attcs
+
+RUN /home/saluser/.checkout_repo.sh ${config}
+
+WORKDIR /home/saluser/
+
+ENV TS_CONFIG_ATTCS_DIR=/home/saluser/ts_config_attcs
+
+ARG idl
+ARG config
+ARG ts_observatory_control
+ARG ataos
+
+RUN source /home/saluser/.setup_sal_env.sh && \
+    conda install -c lsstts \
+    ts-ataos=${atdome} \
+    ts-idl=${idl} \
+    ts-observatory-control=${ts_observatory_control}
+
+LABEL ts_idl=${ts_idl} \
+      ts_observatory_control=${ts_observatory_control} \
+      ts_config_attcs=${config} \
+      ts_ataos=${ataos}
+
+WORKDIR /home/saluser/
+
+COPY startup.sh /home/saluser/.startup.sh
+USER root
+RUN chown saluser:saluser /home/saluser/.startup.sh && \
+    chmod a+x /home/saluser/.startup.sh
+USER saluser

--- a/build/ataos/startup.sh
+++ b/build/ataos/startup.sh
@@ -4,7 +4,7 @@ source $WORKDIR/.setup_sal_env.sh
 
 setup ts_ataos -t current
 
-ataos_csc.py $RUN_ARG &
+ataos_csc.py &
 
 pid="$!"
 

--- a/build/deploy-env/conda/Dockerfile
+++ b/build/deploy-env/conda/Dockerfile
@@ -61,9 +61,7 @@ RUN curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -
     source /home/saluser/.setup_sal_env.sh && \
     conda config --add channels conda-forge && \
     conda install -y cython && \
-    conda install -y -c lsstts python=3.7 ts-dds=${ts_dds} && \
-    conda install -y -c lsstts python=3.7 ts-salobj=${ts_salobj} ts-dds=${ts_dds} || \
-    conda install -y -c lsstts/label/dev python=3.7 ts-salobj=${ts_salobj}
+    conda install -y -c lsstts -c lsstts/label/dev python=3.7 ts-salobj=${ts_salobj} ts-dds=${ts_dds} 
 
 WORKDIR /home/saluser/
 

--- a/build/scheduler/Dockerfile
+++ b/build/scheduler/Dockerfile
@@ -1,0 +1,174 @@
+ARG deploy_tag
+ARG hub=lsstts
+
+FROM ${hub}/aos_sal:${deploy_tag}
+
+WORKDIR ${WORKDIR}
+
+USER lsst
+
+ARG ts_idl
+
+RUN source ${WORKDIR}/.setup_sal_env.sh && \
+    conda install -y asynctest pytest-tornasync && \
+    conda install -y -c lsstts ts-idl=${ts_idl} && \
+    idl_path=$(python -c 'from lsst.ts import idl; import pathlib; print(pathlib.Path(idl.__file__).parents[0])') && \
+    eups declare -m none -r ${idl_path} ts_idl ${ts_idl}
+
+USER saluser
+
+WORKDIR /home/saluser/
+
+RUN mkdir repos/
+
+WORKDIR /home/saluser/repos/
+
+RUN git clone https://github.com/lsst-ts/ts_config_ocs.git && \
+    git clone https://github.com/lsst-ts/ts_scheduler.git && \
+    git clone https://github.com/lsst/sims_seeingModel.git && \
+    git clone https://github.com/lsst/sims_cloudModel.git && \
+    git clone https://github.com/lsst/sims_downtimeModel.git && \
+    git clone https://github.com/lsst/sims_utils.git && \
+    git clone https://github.com/lsst/ephem.git && \
+    git clone https://github.com/lsst/throughputs.git && \
+    git clone https://github.com/lsst/sims_photUtils.git && \
+    git clone https://github.com/lsst/sims_skybrightness.git && \
+    git clone https://github.com/lsst/sims_skybrightness_pre.git && \
+    git clone https://github.com/lsst-ts/ts_dateloc.git && \
+    git clone https://github.com/lsst-ts/ts_astrosky_model.git && \
+    git clone https://github.com/lsst-ts/ts_observatory_model.git && \
+    git clone https://github.com/lsst-ts/scheduler_config.git && \
+    git clone https://github.com/lsst/sims_skybrightness_data.git && \
+    git clone https://github.com/lsst-ts/ts_scriptqueue.git
+
+WORKDIR /home/saluser/repos/sims_utils
+RUN source /opt/lsst/software/stack/loadLSST.bash && \
+    eups declare -r . -t current && \
+    setup sims_utils -t current && \
+    scons
+
+WORKDIR /home/saluser/repos/sims_cloudModel
+RUN source /opt/lsst/software/stack/loadLSST.bash && \
+    eups declare -r . -t current && \
+    setup sims_cloudModel -t current && \
+    scons
+
+WORKDIR /home/saluser/repos/sims_downtimeModel
+RUN source /opt/lsst/software/stack/loadLSST.bash && \
+    eups declare -r . -t current && \
+    setup sims_downtimeModel -t current && \
+    scons
+
+WORKDIR /home/saluser/repos/sims_seeingModel
+RUN source /opt/lsst/software/stack/loadLSST.bash && \
+    eups declare -r . -t current && \
+    setup sims_seeingModel -t current && \
+    scons
+
+WORKDIR /home/saluser/repos/sims_utils
+RUN source /opt/lsst/software/stack/loadLSST.bash && \
+    eups declare -r . -t current && \
+    setup sims_utils -t current && \
+    scons
+
+WORKDIR /home/saluser/repos/ephem
+RUN source /opt/lsst/software/stack/loadLSST.bash && \
+    pip install pyephem && \
+    eups declare -r . -t current
+
+WORKDIR /home/saluser/repos/throughputs
+RUN source /opt/lsst/software/stack/loadLSST.bash && \
+    eups declare -r . -t current
+
+WORKDIR /home/saluser/repos/sims_photUtils
+RUN source /opt/lsst/software/stack/loadLSST.bash && \
+    eups declare -r . -t current && \
+    setup sims_photUtils -t current && \
+    scons
+
+WORKDIR /home/saluser/repos/sims_skybrightness_data
+RUN source /opt/lsst/software/stack/loadLSST.bash && \
+    eups declare -r . -t current
+
+WORKDIR /home/saluser/repos/sims_skybrightness
+RUN source /opt/lsst/software/stack/loadLSST.bash && \
+    eups declare -r . -t current && \
+    setup sims_skybrightness -t current && \
+    scons
+
+WORKDIR /home/saluser/repos/sims_skybrightness_pre
+RUN source /opt/lsst/software/stack/loadLSST.bash && \
+    eups declare -r . -t current && \
+    setup sims_skybrightness_pre -t current && \
+    scons
+
+WORKDIR /home/saluser/repos/ts_dateloc
+RUN source /opt/lsst/software/stack/loadLSST.bash && \
+    eups declare -r . -t current && \
+    setup ts_dateloc -t current && \
+    scons
+
+WORKDIR /home/saluser/repos/ts_astrosky_model
+RUN source /opt/lsst/software/stack/loadLSST.bash && \
+    eups declare -r . -t current && \
+    setup ts_astrosky_model -t current && \
+    scons
+
+WORKDIR /home/saluser/repos/ts_observatory_model
+RUN source /opt/lsst/software/stack/loadLSST.bash && \
+    eups declare -r . -t current && \
+    setup ts_observatory_model -t current && \
+    scons
+
+WORKDIR /home/saluser/repos/scheduler_config
+RUN source /opt/lsst/software/stack/loadLSST.bash && \
+    eups declare -r . -t current
+
+# Work around for deprecated/unneeded packages. Remove when dependency fixed
+WORKDIR /home/saluser/repos/
+
+RUN source /opt/lsst/software/stack/loadLSST.bash && \
+    mkdir python_future && \
+    eups declare -m none -r /home/saluser/repos/python_future python_future git
+
+ARG ts_config_ocs
+
+WORKDIR /home/saluser/repos/ts_config_ocs
+
+RUN source ${WORKDIR}/.setup_sal_env.sh && \
+    /home/saluser/.checkout_repo.sh ${ts_config_ocs} && \
+    eups declare -r . ts_config_ocs ${ts_config_ocs} -t current
+
+ARG ts_scriptqueue
+
+WORKDIR /home/saluser/repos/ts_scriptqueue
+
+RUN source ${WORKDIR}/.setup_sal_env.sh && \
+    /home/saluser/.checkout_repo.sh ${ts_scriptqueue}  && \
+    eups declare -r . ts_scriptqueue ${ts_scriptqueue} -t current
+
+ARG ts_scheduler
+
+WORKDIR /home/saluser/repos/ts_scheduler
+RUN source ${WORKDIR}/.setup_sal_env.sh && \
+    /home/saluser/.checkout_repo.sh ${ts_scheduler} && \
+    eups declare -r . ts_scheduler ${ts_scheduler} -t current && \
+    setup ts_scheduler && \
+    py.test
+
+WORKDIR ${SAL_HOME}
+
+COPY startup.sh /home/saluser/.startup.sh
+USER root
+RUN chown saluser:saluser /home/saluser/.startup.sh && \
+    chmod a+x /home/saluser/.startup.sh
+USER saluser
+
+ENV INDEX=1
+
+LABEL author="Tiago Ribeiro <tribeiro@lsst.org>" \
+      palpy=${palpy}  \
+      sims_data=${sims_data} \
+      sims_survey_fields=${sims_survey_fields} \
+      ts_scheduler=${ts_scheduler} \
+      ts_config_ocs=${ts_config_ocs}

--- a/build/scheduler/startup.sh
+++ b/build/scheduler/startup.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+source ${WORKDIR}/.setup_sal_env.sh
+
+setup ts_scheduler
+
+echo "# Running Scheduler with index: ${INDEX}"
+
+run_scheduler.py $INDEX &
+
+pid="$!"
+
+wait ${pid}

--- a/cycle/cycle.env
+++ b/cycle/cycle.env
@@ -1,12 +1,12 @@
 #
 # Cycle
 #
-CYCLE=c0011
+CYCLE=c0012
 #
 # Base image from lsstsqre.
 #
-lsstsqre=7-stack-lsst_distrib-w_2020_29
-stack=w_2020_29
+lsstsqre=7-stack-lsst_distrib-w_2020_35
+stack=w_2020_35
 #
 # OpenSplice setup
 #
@@ -24,38 +24,45 @@ ts_dds_private=v6.10.4_1
 deploy_env=deploy-env
 hub=ts-dockerhub.lsst.org
 ts_xml=6.1.0
-ts_sal=4.1.4_experimental.2
-ts_idl=1.3.0
-ts_salobj=v5.17.0_experimental.2
+ts_sal=5.0.0_experimental.2
+ts_idl=1.4.0
+ts_salobj=v6.0.0.experimental.7
 #
 # Products
 #
 ts_hexrotcomm=0.6.0
 ts_simactuators=2.0.0
 ts_ATDome=1.2.1
-ts_ATDomeTrajectory=1.3.3
+ts_ATDomeTrajectory=1.4.1
 ts_ATMCSSimulator=1.0.4
 ts_ATPneumaticsSimulator=0.5.4
-ts_athexapod=0.5.0
-ts_atspec=0.5.1
+ts_athexapod=0.6.0
+ts_atspec=0.6.0
 ts_rotator=0.4.4
 ts_hexapod=0.6.0
 ts_salkafka=1.4.0.rc.6
-ts_observatory_control=0.3.0
-ts_standardscripts=1.3.0
+ts_observatory_control=0.4.0
+ts_standardscripts=1.4.0-rc.1
 ts_externalscripts=0.5.1
-ts_scriptqueue=2.6.3
-ts_ataos=1.6.1.rc.3
+ts_scriptqueue=2.6.4
+ts_ataos=1.6.1
 ts_m2=0.2.0
 ts_mtmount=0.4.0
 ts_pointing_common=2.1.0
 ts_m1m3support=v1.8
-ts_mtaos=v0.4.1
+ts_mtaos=v0.4.3
 phosim_utils=8744592
 ts_wep=v1.4.4
 ts_ofc=v1.3.1
 ts_phosim=v1.2.3
 ts_watcher=1.1.0
+ts_scheduler=1.4.0
+#
+# Additional packages needed by Scheduler
+#
+palpy=1.8.1+6
+sims_data=2018.05.08
+sims_survey_fields=2.6.0.sims+40
 #
 # Configuration Packages
 #

--- a/cycle/docker-compose.yaml
+++ b/cycle/docker-compose.yaml
@@ -257,7 +257,7 @@ services:
         xml: ${ts_xml}
         m1m3: ${ts_m1m3support}
       args:
-        rpm: ${ts_sal}-${ts_xml}.el7.x86_64
+        rpm: ${ts_xml}-${ts_sal}.el7.x86_64
         m1m3: ${ts_m1m3support}
         dds_version: ${dds_private_version}
         dds_private_version: ${dds_private_version}
@@ -323,10 +323,10 @@ services:
       dockerfile: ./ptg/Dockerfile
       labels:
         com.description: "Pointing component deployment image for cycle ${CYCLE}."
-        rpm: 0:${ts_sal}-${ts_xml}.el7.x86_64
+        rpm: 0:${ts_xml}-${ts_sal}.el7.x86_64
         ptg: ${ts_pointing_common}
       args:
-        rpm: 0:${ts_sal}-${ts_xml}.el7.x86_64
+        rpm: 0:${ts_xml}-${ts_sal}.el7.x86_64
         ptg: ${ts_pointing_common}
         dds_version: ${dds_private_version}
         dds_private_version: ${dds_private_version}
@@ -347,6 +347,20 @@ services:
         deploy_tag: ${CYCLE}
         idl: ${ts_idl}_${ts_xml}_${ts_sal}
         salkafka: v${ts_salkafka}
+
+  scheduler:
+    image: ${hub}/scheduler:${CYCLE}
+    build:
+      context: ../build/scheduler
+      labels:
+        com.description: "Scheduler image for cycle ${CYCLE}"
+      args:
+        hub: ${hub}
+        deploy_tag: ${CYCLE}
+        ts_config_ocs: ${ts_config_ocs}
+        ts_idl: ${ts_idl}
+        ts_scriptqueue: ${ts_scriptqueue}
+        ts_scheduler: ${ts_scheduler}
 
   scriptqueue:
     image: ${hub}/scriptqueue:${CYCLE}


### PR DESCRIPTION
Update README with information on the new cycle.
Add Scheduler build scripts.
Update cycle number.
Update stack to w_2020_35.
Update ts_sal version.
Update ts_salobj version.
Update rpm name tag in m1m3 build.
Update ts_idl version.
Update ts_ataos version.
Update ts_atspec version.
Update ts_athexapod version.
Update ts_MTAOS version.
Update ts_observatory_control version.
Update ts_standardscript version.
Updatte ts_scriptqueue version.
Update ts_atdometrajectory version.