### PR TITLE
DM-29506: Support black upgrade

### DIFF
--- a/build/develop-env/lsstsqre/Dockerfile
+++ b/build/develop-env/lsstsqre/Dockerfile
@@ -91,6 +91,8 @@ USER saluser
 
 WORKDIR /home/saluser
 
+ARG ts_develop
+
 RUN source ${WORKDIR}/loadLSST.bash && \
    conda install -y -c lsstts ts-develop=${ts_develop}
 

--- a/cycle/develop.env
+++ b/cycle/develop.env
@@ -33,7 +33,7 @@ ts_salobj=develop
 #
 # Products
 #
-ts_develop=0.2.0
+ts_develop=0.3.0
 ts_hexrotcomm=develop
 ts_simactuators=develop
 ts_ATDome=develop

--- a/cycle/docker-compose.yaml
+++ b/cycle/docker-compose.yaml
@@ -427,6 +427,7 @@ services:
         dds_community_version: ${dds_community_version}
         dds_community_build: ${dds_community_build}
         ts_dds: ${ts_dds_community}
+        ts_develop: ${ts_develop}
         UID: ${UID}
         GID: ${GID}
 

--- a/cycle/master.env
+++ b/cycle/master.env
@@ -33,7 +33,7 @@ ts_salobj=master
 #
 # Products
 #
-ts_develop=0.2.0
+ts_develop=0.3.0
 ts_hexrotcomm=master
 ts_simactuators=master
 ts_ATDome=master


### PR DESCRIPTION
Fix base develop-env image build to include ts_develop argument.
Update `ts_develop` version in `cycle/develop.env` and `cycle/master.env` to 0.3.0.