### PR TITLE
DM-29896: Support building sal-sciplat container in cycle build

### DIFF
--- a/cycle/cycle.env
+++ b/cycle/cycle.env
@@ -5,7 +5,7 @@ CYCLE=c0019
 #
 # Revision
 #
-rev=.001
+rev=.002
 #
 # Core packages, e.g.; SalObj Container
 # WARNING: If any of the following packages change, the cycle number must be
@@ -47,7 +47,7 @@ ts_dds_private_conda_build=py38_16
 # Products
 #
 ts_develop=0.3.1
-ts_hexrotcomm=0.18.1b2
+ts_hexrotcomm=0.19.0a1
 ts_simactuators=2.2.2
 ts_ATDome=1.6.0
 ts_ATDomeTrajectory=1.6.0


### PR DESCRIPTION
I created a revision 2 so that I could build the rotator image with a different version of hexrotcomm for Russell to test. 