### PR TITLE
Cycle 23 revision 004.

### DIFF
--- a/cycle/cycle.env
+++ b/cycle/cycle.env
@@ -5,7 +5,7 @@ CYCLE=c0023
 #
 # Revision
 #
-rev=.003
+rev=.004
 #
 # Core packages, e.g.; SalObj Container
 # WARNING: If any of the following packages change, the cycle number must be
@@ -47,7 +47,7 @@ ts_dds_private_conda_build=py38_0
 # Products
 #
 ts_develop=0.3.4
-ts_hexrotcomm=0.23.1
+ts_hexrotcomm=0.25.0
 ts_simactuators=2.2.3
 ts_adamSensors=0.1.1a1
 ts_ATDome=1.6.1

--- a/cycle/develop.env
+++ b/cycle/develop.env
@@ -16,11 +16,11 @@ stack=w_latest
 dds_community_version=6.9.0
 dds_community_build=16.el7
 ts_dds_community=6.9.0
-ts_dds_community_conda_build=py38_16
+ts_dds_community_conda_build=py38_18
 dds_private_version=6.10.4
 dds_private_build=6.el7
 ts_dds_private=6.10.4
-ts_dds_private_conda_build=py38_0
+ts_dds_private_conda_build=py38_18
 #
 # Base packages, e.g.; SalObj Container
 #

--- a/cycle/main.env
+++ b/cycle/main.env
@@ -16,11 +16,11 @@ stack=w_latest
 dds_community_version=6.9.0
 dds_community_build=16.el7
 ts_dds_community=6.9.0
-ts_dds_community_conda_build=py38_16
+ts_dds_community_conda_build=py38_18
 dds_private_version=6.10.4
 dds_private_build=6.el7
 ts_dds_private=6.10.4
-ts_dds_private_conda_build=py38_0
+ts_dds_private_conda_build=py38_18
 #
 # Base packages, e.g.; SalObj Container
 #

--- a/doc/version-history.rst
+++ b/doc/version-history.rst
@@ -8,6 +8,13 @@ Version History
 .. No new work should be required in order to complete this section.
 .. Below is an example of a version history format.
 
+Cycle 23 revision 4
+===================
+
+* On develop and main builds update build number of the dds python bindings.
+* Update version of the following packages:
+  * ts_hexrotcomm
+
 Cycle 23 revision 3
 ===================
 


### PR DESCRIPTION
On develop and main builds update build number of the dds python bindings.
Update version of the following packages:
    * ts_hexrotcomm