### PR TITLE
OSW-2238: Replace libserdes with libschemaregistry in the salobj image

### DIFF
--- a/build/develop-env/salobj/Dockerfile
+++ b/build/develop-env/salobj/Dockerfile
@@ -96,13 +96,17 @@ USER root
 #     ${LSST_SAL_PREFIX}/bin/setupStackBuildEnvironment
 
 RUN source /home/saluser/.setup_salobj.sh && \
-    ${LSST_SAL_PREFIX}/bin/setupSALKafkaBuildEnvironment avro || echo "Failed."
+    ${LSST_SAL_PREFIX}/bin/setupSALKafkaBuildEnvironment avro
 
 RUN source /home/saluser/.setup_salobj.sh && \
-    ${LSST_SAL_PREFIX}/bin/setupSALKafkaBuildEnvironment librdkafka || echo "Failed."
+    ${LSST_SAL_PREFIX}/bin/setupSALKafkaBuildEnvironment librdkafka
+
+# zip is required by vcpkg, which builds libschemaregistry's dependencies
+# (the base image provides unzip but not zip).
+RUN dnf install -y zip
 
 RUN source /home/saluser/.setup_salobj.sh && \
-    ${LSST_SAL_PREFIX}/bin/setupSALKafkaBuildEnvironment libserdes || echo "Failed."
+    ${LSST_SAL_PREFIX}/bin/setupSALKafkaBuildEnvironment libschemaregistry
 
 USER saluser
 


### PR DESCRIPTION
Build libschemaregistry via the new ts_sal helper and pin ts_sal to the migration branch until it merges.